### PR TITLE
修复sidebar overflow background color

### DIFF
--- a/src/assets/css/layout.scss
+++ b/src/assets/css/layout.scss
@@ -662,3 +662,8 @@
 .el-drawer__body {
   padding: $paddingWidth;
 }
+
+// ----------sidebar menu background color fix----------
+.el-aside>.el-menu {
+  overflow: auto;
+}


### PR DESCRIPTION
bug显示为：首先切换到暗黑模式，当侧边栏高度超过屏幕高度，出现滚动条时，最下面部分的背景色为白色。
此次提交为修复这个bug。